### PR TITLE
Missing "+" wildcard verification fix

### DIFF
--- a/src/main/java/com/hivemq/extensions/rbac/FileAuthAuthenticator.java
+++ b/src/main/java/com/hivemq/extensions/rbac/FileAuthAuthenticator.java
@@ -59,14 +59,14 @@ public class FileAuthAuthenticator implements SimpleAuthenticator {
         final String userName = userNameOptional.get();
 
         //prevent clientIds with MQTT wildcard characters
-        if (clientId.contains("#")) {
+        if (clientId.contains("#") || clientId.contains("+")) {
             //client is not authenticated
             simpleAuthOutput.failAuthentication(ConnackReasonCode.CLIENT_IDENTIFIER_NOT_VALID, "The characters '#' and '+' are not allowed in the client identifier");
             return;
         }
 
         //prevent usernames with MQTT wildcard characters
-        if (userName.contains("#")) {
+        if (userName.contains("#") || userName.contains("+")) {
             //client is not authenticated
             simpleAuthOutput.failAuthentication(ConnackReasonCode.BAD_USER_NAME_OR_PASSWORD, "The characters '#' and '+' are not allowed in the username");
             return;

--- a/src/test/java/com/hivemq/extensions/rbac/FileAuthAuthenticatorTest.java
+++ b/src/test/java/com/hivemq/extensions/rbac/FileAuthAuthenticatorTest.java
@@ -94,13 +94,13 @@ public class FileAuthAuthenticatorTest {
     @Test
     public void test_connect_with_wildcard_client() {
         fileAuthAuthenticator.onConnect(new TestInput("client1/#", "user1", "pass1"), output);
-        verify(output).failAuthentication(ConnackReasonCode.BAD_USER_NAME_OR_PASSWORD, "The characters '#' and '+' are not allowed in the username");
+        verify(output).failAuthentication(ConnackReasonCode.CLIENT_IDENTIFIER_NOT_VALID, "The characters '#' and '+' are not allowed in the client identifier");
     }
 
     @Test
     public void test_connect_with_plus_wildcard_client() {
         fileAuthAuthenticator.onConnect(new TestInput("client1/+", "user1", "pass1"), output);
-        verify(output).failAuthentication(ConnackReasonCode.BAD_USER_NAME_OR_PASSWORD, "The characters '#' and '+' are not allowed in the username");
+        verify(output).failAuthentication(ConnackReasonCode.CLIENT_IDENTIFIER_NOT_VALID, "The characters '#' and '+' are not allowed in the client identifier");
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/rbac/TestMQIT.java
+++ b/src/test/java/com/hivemq/extensions/rbac/TestMQIT.java
@@ -127,7 +127,7 @@ public class TestMQIT {
                 Mqtt5ConnAckException.class,
                 ()-> publisher.toBlocking().connect()
         );
-        assertEquals(Mqtt5ConnAckReasonCode.CLIENT_IDENTIFIER_NOT_VALID, thrown.getMqttMessage().getReasonCode());
+        assertEquals(Mqtt5ConnAckReasonCode.BAD_USER_NAME_OR_PASSWORD, thrown.getMqttMessage().getReasonCode());
     }
 
     @Test
@@ -142,6 +142,6 @@ public class TestMQIT {
                 Mqtt5ConnAckException.class,
                 ()-> publisher.toBlocking().connect()
         );
-        assertEquals(Mqtt5ConnAckReasonCode.CLIENT_IDENTIFIER_NOT_VALID, thrown.getMqttMessage().getReasonCode());
+        assertEquals(Mqtt5ConnAckReasonCode.BAD_USER_NAME_OR_PASSWORD, thrown.getMqttMessage().getReasonCode());
     }
 }


### PR DESCRIPTION
As described in https://github.com/siksterkashop/hiveMQTask/issues/4, we need to verify both wildcard characters.
Change needs to be done in src/main/java/com/hivemq/extensions/rbac/FileAuthAuthenticator.java:
```
if (clientId.contains("#") || clientId.contains("+")) {
            //client is not authenticated
            simpleAuthOutput.failAuthentication(ConnackReasonCode.CLIENT_IDENTIFIER_NOT_VALID, "The characters '#' and '+' are not allowed in the client identifier");
            return;
        }

if (userName.contains("#") || userName.contains("+")) {
            //client is not authenticated
            simpleAuthOutput.failAuthentication(ConnackReasonCode.BAD_USER_NAME_OR_PASSWORD, "The characters '#' and '+' are not allowed in the username");
            return;
        }
```
